### PR TITLE
Load configuration from .namerctl.ext files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,33 @@ This utility _will change_ drastically in the near future.
 ## Usage ##
 
 ```
-:; namerctl dtab help
-Control namer's dtab interface
+$ namerctl help
+namerd manages delegation tables for linkerd.
+
+namerctl looks for a configuration file in the current working
+directory or any of its parent directories. Configuration files are
+named .namerctl.<ext> where <ext> is describes one of several formats
+including yaml, json, toml, etc.  "base-url" is currently the only
+supported configuration.  Furthermore, the base url may be specified
+via the NAMERCTL_BASE_URL environment variable.
+
+Find more information at https://linkerd.io
+
+Usage:
+  namerctl [command]
+
+Available Commands:
+  dtab        Control namerd's delegation tables
+
+Flags:
+      --base-url string   namer location (e.g. http://namerd.example.com:4080)
+      --config string     config file
+
+Use "namerctl [command] --help" for more information about a command.
+```
+```
+$ namerctl dtab help
+Control namerd's delegation tables
 
 Usage:
   namerctl dtab [command]
@@ -29,9 +54,9 @@ Available Commands:
 
 Global Flags:
       --base-url string   namer location (e.g. http://namerd.example.com:4080)
+      --config string     config file
 
-Use "namerctl dtab [command] --help" for more information about a
-command.
+Use "namerctl dtab [command] --help" for more information about a command.
 ```
 
 ## License ##

--- a/cmd/dtab.go
+++ b/cmd/dtab.go
@@ -15,8 +15,7 @@ import (
 var (
 	dtabCmd = &cobra.Command{
 		Use:   "dtab",
-		Short: "Control namer's dtab interface",
-		Long:  ``,
+		Short: "Control namerd's delegation tables",
 	}
 
 	dtabListCmd = &cobra.Command{

--- a/cmd/dtab.go
+++ b/cmd/dtab.go
@@ -169,7 +169,8 @@ func init() {
 
 	dtabCmd.AddCommand(dtabCreateCmd)
 
-	dtabUpdateCmd.PersistentFlags().StringVar(&dtabUpdateVersion, "version", "", "only perform update if the current version matches")
+	dtabUpdateCmd.PersistentFlags().StringVar(&dtabUpdateVersion, "version", "",
+		"only perform update if the current version matches")
 	dtabCmd.AddCommand(dtabUpdateCmd)
 
 	dtabCmd.AddCommand(dtabDeleteCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,17 +90,18 @@ func addParentConfigPaths(dir string) {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if cfgFile != "" { // enable ability to specify config file via flag
+	if cfgFile != "" { // set on commandline
 		viper.SetConfigFile(cfgFile)
 	}
-	viper.SetConfigName(".namerctl") // name of config file (without extension)
+	viper.SetConfigName(".namerctl")
 	addParentConfigPaths(os.Getenv("PWD"))
 	viper.SetEnvPrefix("namerctl")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 
 	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	if err := viper.ReadInConfig(); err != nil {
+		fmt.Fprintf(os.Stderr, "Could not use config file: %s: %s",
+			viper.ConfigFileUsed(), err)
 	}
 }


### PR DESCRIPTION
Configurations are searched in all parent directories (similarly to how `git`
works).

Environment variables are also supported

Fixes #7