### PR TITLE
Fix help text when config file is missing

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,7 +101,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
-		fmt.Fprintf(os.Stderr, "Could not use config file: %s: %s",
-			viper.ConfigFileUsed(), err)
+		fmt.Fprintln(os.Stderr, err)
 	}
 }


### PR DESCRIPTION
Previously:

```
$ namerctl help
Could not use config file: : Unsupported Config Type ""namerd manages delegation tables for linkerd.

namerctl looks for a configuration file in the current working ...
```

Now:

```
$ namerctl help
Unsupported Config Type ""
namerd manages delegation tables for linkerd.

namerctl looks for a configuration file in the current working ...
```