### PR TITLE
Remove newlines from parsed dtab

### DIFF
--- a/namer/dtab.go
+++ b/namer/dtab.go
@@ -23,6 +23,7 @@ var (
 // pairs. The dtab string must be validated and stripped of comments
 // before being parsed.
 func parseDtab(dtabStr string) (Dtab, error) {
+	dtabStr = strings.Replace(dtabStr, "\n", "", -1)
 	if dtabStr == "" {
 		return Dtab([]*Dentry{}), nil
 	}

--- a/namer/dtab_test.go
+++ b/namer/dtab_test.go
@@ -12,16 +12,22 @@ type dtabtest struct {
 var testdtabs = []dtabtest{
 	dtabtest{"", true, []*Dentry{}, ""},
 	dtabtest{
-		`/foo=>/bar;/foo=>/bah#word`,
+		"/foo=>/bar;/foo=>/bah#word",
 		true,
 		[]*Dentry{&Dentry{"/foo", "/bar"}, &Dentry{"/foo", "/bah#word"}},
 		"/foo  => /bar ;\n/foo  => /bah#word ;\n",
 	},
 	dtabtest{
-		`/foo=>/bar;/foo/bar/baz=>/bah#word;`,
+		"/foo=>/bar;/foo/bar/baz=>/bah#word;",
 		true,
 		[]*Dentry{&Dentry{"/foo", "/bar"}, &Dentry{"/foo/bar/baz", "/bah#word"}},
 		"/foo          => /bar ;\n/foo/bar/baz  => /bah#word ;\n",
+	},
+	dtabtest{
+		"/foo=>/bar;/foo/bar/baz=>/bah\n",
+		true,
+		[]*Dentry{&Dentry{"/foo", "/bar"}, &Dentry{"/foo/bar/baz", "/bah"}},
+		"/foo          => /bar ;\n/foo/bar/baz  => /bah ;\n",
 	},
 }
 


### PR DESCRIPTION
At some point the namerd api changed to append a newline to dtabs, which causes
dtab printing to be slightly misformatted.

Fix this by removing newlines when parsing dtabs.