### PR TITLE
Add --json flag for json output/input

### DIFF
--- a/cmd/dtab.go
+++ b/cmd/dtab.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -29,12 +30,16 @@ var (
 				if err != nil {
 					return err
 				}
-				names, json, err := ctl.List()
+				names, err := ctl.List()
 				if err != nil {
 					return err
 				}
 				if dtabJson {
-					fmt.Println(json)
+					bytes, err := json.Marshal(names)
+					if err != nil {
+						return err
+					}
+					fmt.Println(string(bytes))
 				} else {
 					fmt.Println(strings.Join(names, "\n"))
 				}
@@ -62,25 +67,23 @@ var (
 					return err
 				}
 				name := args[0]
-				vd, json, err := ctl.Get(name, dtabJson)
+				vd, err := ctl.Get(name)
 				if err != nil {
 					return err
 				}
 				if dtabJson {
+					bytes, err := json.Marshal(vd)
+					if err != nil {
+						return err
+					}
+					fmt.Println(string(bytes))
+				} else if dtabGetPretty {
 					if vd.Version != namer.Version("") {
-						fmt.Printf("{\"version\": \"%s\", \"dtab\": %s}", vd.Version, strings.Replace(json, "\n", "", -1))
-					} else {
-						fmt.Println(json)
+						fmt.Printf("# version %s\n", vd.Version)
 					}
+					fmt.Print(vd.Dtab.Pretty())
 				} else {
-					if dtabGetPretty {
-						if vd.Version != namer.Version("") {
-							fmt.Printf("# version %s\n", vd.Version)
-						}
-						fmt.Print(vd.Dtab.Pretty())
-					} else {
-						fmt.Println(vd.Dtab.String())
-					}
+					fmt.Println(vd.Dtab.String())
 				}
 
 				return nil
@@ -107,7 +110,7 @@ var (
 				if err != nil {
 					return err
 				}
-				_, err = ctl.Create(name, dtabstr, dtabJson)
+				_, err = ctl.Create(name, dtabstr)
 				if err != nil {
 					return err
 				}
@@ -138,7 +141,7 @@ var (
 				if err != nil {
 					return err
 				}
-				_, err = ctl.Update(name, dtabstr, dtabJson, namer.Version(dtabUpdateVersion))
+				_, err = ctl.Update(name, dtabstr, namer.Version(dtabUpdateVersion))
 				if err != nil {
 					return err
 				}

--- a/namer/controller.go
+++ b/namer/controller.go
@@ -107,32 +107,33 @@ func isJson(str string) bool {
 }
 
 func (ctl *httpController) Create(name, dtabstr string) (Version, error) {
+	emptyVersion := Version("")
 	var req *http.Request
-	if j := isJson(dtabstr); j {
+	if isJson(dtabstr) {
 		var vdtab VersionedDtab
 		if err := json.Unmarshal([]byte(dtabstr), &vdtab); err != nil {
-			return Version(""), err
+			return emptyVersion, err
 		}
 		dtab, err := json.Marshal(vdtab.Dtab)
 		if err != nil {
-			return Version(""), err
+			return emptyVersion, err
 		}
 		req, err = ctl.dtabRequest("POST", name, strings.NewReader(string(dtab)))
 		if err != nil {
-			return Version(""), err
+			return emptyVersion, err
 		}
 		req.Header.Set("Content-Type", "application/json")
 	} else {
 		req, err := ctl.dtabRequest("POST", name, strings.NewReader(dtabstr))
 		if err != nil {
-			return Version(""), err
+			return emptyVersion, err
 		}
 		req.Header.Set("Content-Type", "application/dtab")
 	}
 
 	rsp, err := ctl.client.Do(req)
 	if err != nil {
-		return Version(""), err
+		return emptyVersion, err
 	}
 	defer drainAndClose(rsp)
 
@@ -142,7 +143,7 @@ func (ctl *httpController) Create(name, dtabstr string) (Version, error) {
 		return v, nil
 
 	default:
-		return Version(""), fmt.Errorf("unexpected response: %s", rsp.Status)
+		return emptyVersion, fmt.Errorf("unexpected response: %s", rsp.Status)
 	}
 }
 

--- a/namer/dtab.go
+++ b/namer/dtab.go
@@ -7,8 +7,11 @@ import (
 )
 
 type (
-	Dentry struct{ Prefix, Destination string }
-	Dtab   []*Dentry
+	Dentry struct {
+		Prefix      string `json:"prefix"`
+		Destination string `json:"dst"`
+	}
+	Dtab []*Dentry
 )
 
 func (dentry *Dentry) String() string {


### PR DESCRIPTION
It's easier to use namerctl programmatically if the format is json. This adds the --json flag for dtab commands.