### PR TITLE
Fix a scope bug where req would revert to nil when creating a dtab

### DIFF
--- a/namer/controller.go
+++ b/namer/controller.go
@@ -109,6 +109,7 @@ func isJson(str string) bool {
 func (ctl *httpController) Create(name, dtabstr string) (Version, error) {
 	emptyVersion := Version("")
 	var req *http.Request
+	var err error
 	if isJson(dtabstr) {
 		var vdtab VersionedDtab
 		if err := json.Unmarshal([]byte(dtabstr), &vdtab); err != nil {
@@ -124,7 +125,7 @@ func (ctl *httpController) Create(name, dtabstr string) (Version, error) {
 		}
 		req.Header.Set("Content-Type", "application/json")
 	} else {
-		req, err := ctl.dtabRequest("POST", name, strings.NewReader(dtabstr))
+		req, err = ctl.dtabRequest("POST", name, strings.NewReader(dtabstr))
 		if err != nil {
 			return emptyVersion, err
 		}


### PR DESCRIPTION
causing a panic.

``` sh
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0xbac08]

goroutine 1 [running]:
panic(0x519200, 0xc82000e110)
        /usr/local/Cellar/go/1.6/libexec/src/runtime/panic.go:464 +0x3e6
net/http.(*Client).Do(0xc82013c8a0, 0x0, 0xc, 0x0, 0x0)
        /usr/local/Cellar/go/1.6/libexec/src/net/http/client.go:186 +0x2e8
github.com/buoyantio/namerctl/namer.(*httpController).Create(0xc820136ea0, 0x7fff5fbff795, 0x7, 0xc820016480, 0x59, 0x0, 0x0, 0x0, 0x0)
        /Users/nick/go/src/github.com/buoyantio/namerctl/namer/controller.go:134 +0x495
github.com/buoyantio/namerctl/cmd.glob.func3(0x872040, 0xc8200bdb80, 0x2, 0x2, 0x0, 0x0)
        /Users/nick/go/src/github.com/buoyantio/namerctl/cmd/dtab.go:113 +0x174
github.com/spf13/cobra.(*Command).execute(0x872040, 0xc8200bd8e0, 0x2, 0x2, 0x0, 0x0)
        /Users/nick/go/src/github.com/spf13/cobra/command.go:632 +0x6bb
github.com/spf13/cobra.(*Command).ExecuteC(0x8726a0, 0x872040, 0x0, 0x0)
        /Users/nick/go/src/github.com/spf13/cobra/command.go:722 +0x55c
github.com/spf13/cobra.(*Command).Execute(0x8726a0, 0x0, 0x0)
        /Users/nick/go/src/github.com/spf13/cobra/command.go:681 +0x2d
github.com/buoyantio/namerctl/cmd.Execute()
        /Users/nick/go/src/github.com/buoyantio/namerctl/cmd/root.go:69 +0x27
main.main()
        /Users/nick/go/src/github.com/buoyantio/namerctl/main.go:6 +0x14
```

Steps to reproduce:
1. Start with a fresh install of namerd.
2. Create a `default.dtab`.
3. Call `namerctl dtab create default ./default.dtab`
4. See the panic as above.
